### PR TITLE
IPv6 support missing - use url-lite as an optional parsing backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ exclude = [".github"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
+url-lite = { version = "0.1.0", optional = true }
+
+[features]
+url-lite-backend = ["dep:url-lite"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,4 +5,6 @@ pub enum Error {
     NoScheme,
     /// The sceme in the url is not known
     UnsupportedScheme,
+    /// The url is invalid
+    InvalidUrl,
 }


### PR DESCRIPTION
Hello,

I'd like to use `reqwless` in scenario where IPv6 address is used as host in url.

`nourl` doesn't support IPv6 parsing yet. To prevent reinventing the wheel, I added optional dependency on `url-lite` crate, which supports IPv6, and feature `url-lite-backend` to enable parsing using `url-lite` as a backend.

Would you accept such quick solution?

In my opinion it's better then duplicating and then maintaining code from `url-lite`.
Or maybe it would be better to switch `reqwless` to use `url-lite` directly?

Thanks!