### PR TITLE
Fix Hostname Parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_path_with_colon() {
+        let url = Url::parse("http://localhost/foo/bar:123").unwrap();
+        assert_eq!(url.scheme(), UrlScheme::HTTP);
+        assert_eq!(url.host(), "localhost");
+        assert_eq!(url.port_or_default(), 80);
+        assert_eq!(url.path(), "/foo/bar:123");
+
+        assert_eq!("http://localhost/foo/bar:123", std::format!("{:?}", url));
+    }
+
+    #[test]
     fn test_parse_port() {
         let url = Url::parse("http://localhost:8088").unwrap();
         assert_eq!(url.scheme(), UrlScheme::HTTP);


### PR DESCRIPTION
Original problem: https://github.com/drogue-iot/reqwless/issues/111

When parsing URLs with a colon in the path, nourl would incorrectly include part of the path as part of the host.

Example (in the issue above): `https://api.telegram.org/bot123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11/getMe`

In this case the host would be parsed as `api.telegram.org/bot123456`.

This PR provides a fix for this, by first splitting the path and host+port, before considering the host+optional port.