### PR TITLE
Add support for Query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["embedded", "url", "no_std"]
 exclude = [".github"]
 
 [dependencies]
-defmt = { version = "0.3", optional = true }
+defmt = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ The crate runs on stable rust.
 
 ## Example
 ```rust
-let url = Url::parse("http://localhost/foo/bar").unwrap();
+let url = Url::parse("http://localhost/foo/bar?foo=bar&hello=world").unwrap();
 assert_eq!(url.scheme(), UrlScheme::HTTP);
 assert_eq!(url.host(), "localhost");
 assert_eq!(url.port_or_default(), 80);
 assert_eq!(url.path(), "/foo/bar");
+assert_eq!(url.query(), Some("foo=bar&hello=world"));
 ```
 
 The implementation is heavily inspired (close to copy/paste) from the Url type in [reqwless](https://github.com/drogue-iot/reqwless).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,10 @@ impl<'a> Url<'a> {
             Ok(UrlScheme::HTTP)
         } else if scheme.eq_ignore_ascii_case("https") {
             Ok(UrlScheme::HTTPS)
+        } else if scheme.eq_ignore_ascii_case("mqtt") {
+            Ok(UrlScheme::MQTT)
+        } else if scheme.eq_ignore_ascii_case("mqtts") {
+            Ok(UrlScheme::MQTTS)
         } else {
             Err(Error::UnsupportedScheme)
         }?;
@@ -311,6 +315,13 @@ mod tests {
         assert_eq!(url.port_or_default(), 80);
         assert_eq!(url.path(), "/");
         assert_eq!(url.query(), None);
+
+        let url = Url::parse("mqtt://").unwrap();
+        assert_eq!(url.scheme(), UrlScheme::MQTT);
+        assert_eq!(url.host(), "");
+        assert_eq!(url.port_or_default(), 1883);
+        assert_eq!(url.path(), "/");
+        assert_eq!(url.query(), None);
     }
 
     #[test]
@@ -348,15 +359,15 @@ mod tests {
 
     #[test]
     fn test_parse_path_query() {
-        let url = Url::parse("http://localhost/foo/bar?foo=bar&hello=world").unwrap();
-        assert_eq!(url.scheme(), UrlScheme::HTTP);
+        let url = Url::parse("mqtt://localhost/foo/bar?foo=bar&hello=world").unwrap();
+        assert_eq!(url.scheme(), UrlScheme::MQTT);
         assert_eq!(url.host(), "localhost");
-        assert_eq!(url.port_or_default(), 80);
+        assert_eq!(url.port_or_default(), 1883);
         assert_eq!(url.path(), "/foo/bar");
         assert_eq!(url.query(), Some("foo=bar&hello=world"));
 
         assert_eq!(
-            "http://localhost/foo/bar?foo=bar&hello=world",
+            "mqtt://localhost/foo/bar?foo=bar&hello=world",
             std::format!("{:?}", url)
         );
     }


### PR DESCRIPTION
### summary:
Hi, this PR implements the support for query. Now `nourl` parser can accepts `scheme://host:port/path?query` rather than `scheme://host:port/path`.

### change:
1. Update `defmt` to `1.0`
2. Add query support 
3. Fix MQTT protocol support

Thanks for review~